### PR TITLE
Remove Cartfile dependency files

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "daltoniam/Starscream" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "daltoniam/Starscream" "3.1.0"


### PR DESCRIPTION
Starscream is no longer a Carthage dependency, so we should get rid of these files. This also speeds up Carthage bootstrap time since it won't download starscream.